### PR TITLE
Add Launchpad Remote Build support

### DIFF
--- a/__tests__/build.test.ts
+++ b/__tests__/build.test.ts
@@ -1,6 +1,7 @@
 // -*- mode: javascript; js-indent-level: 2 -*-
 
 import fs = require('fs')
+import * as core from '@actions/core'
 import * as exec from '@actions/exec'
 import * as build from '../src/build'
 import * as tools from '../src/tools'
@@ -43,6 +44,102 @@ test('SnapcraftBuilder.build runs a snap build', async () => {
   )
 })
 
+test('SnapcraftBuilder.build runs a Launchpad snap build', async () => {
+  expect.assertions(4)
+
+  const ensureSnapd = jest
+    .spyOn(tools, 'ensureSnapd')
+    .mockImplementation(async (): Promise<void> => {})
+  const ensureLXD = jest
+    .spyOn(tools, 'ensureLXD')
+    .mockImplementation(async (): Promise<void> => {})
+  const ensureSnapcraft = jest
+    .spyOn(tools, 'ensureSnapcraft')
+    .mockImplementation(async (): Promise<void> => {})
+  const execMock = jest.spyOn(exec, 'exec').mockImplementation(
+    async (program: string, args?: string[]): Promise<number> => {
+      return 0
+    }
+  )
+  const getInputMock = jest
+    .spyOn(core, 'getInput')
+    .mockImplementation((name: string): string => {
+      switch (name) {
+        case 'use_launchpad':
+          return 'true'
+        case 'launchpad_accept_public_upload':
+          return 'true'
+        case 'launchpad_timeout':
+          return '600'
+        default:
+          return ''
+      }
+    })
+
+  const projectDir = 'project-root'
+  const builder = new build.SnapcraftBuilder(projectDir)
+  await builder.build()
+
+  expect(ensureSnapd).toHaveBeenCalled()
+  expect(ensureLXD).not.toHaveBeenCalled()
+  expect(ensureSnapcraft).toHaveBeenCalled()
+  expect(execMock).toHaveBeenCalledWith(
+    'snapcraft',
+    [
+      'remote-build',
+      '--launchpad-accept-public-upload',
+      '--launchpad-timeout=600'
+    ],
+    {
+      cwd: projectDir
+    }
+  )
+})
+
+test('SnapcraftBuilder.build fails when Launchpad build requested without acknowledging public uploads', async () => {
+  expect.assertions(5)
+
+  const ensureSnapd = jest
+    .spyOn(tools, 'ensureSnapd')
+    .mockImplementation(async (): Promise<void> => {})
+  const ensureLXD = jest
+    .spyOn(tools, 'ensureLXD')
+    .mockImplementation(async (): Promise<void> => {})
+  const ensureSnapcraft = jest
+    .spyOn(tools, 'ensureSnapcraft')
+    .mockImplementation(async (): Promise<void> => {})
+  const execMock = jest.spyOn(exec, 'exec').mockImplementation(
+    async (program: string, args?: string[]): Promise<number> => {
+      return 0
+    }
+  )
+  const getInputMock = jest
+    .spyOn(core, 'getInput')
+    .mockImplementation((name: string): string => {
+      switch (name) {
+        case 'use_launchpad':
+          return 'true'
+        case 'launchpad_accept_public_upload':
+          return ''
+        case 'launchpad_timeout':
+          return ''
+        default:
+          return ''
+      }
+    })
+
+  const projectDir = 'project-root'
+  const builder = new build.SnapcraftBuilder(projectDir)
+  await expect(builder.build()).rejects.toThrow(
+    'Launchpad builds are publically accessible. You must acknowledge this by setting "launchpad_accept_public_upload" to true.'
+  )
+
+  expect(ensureSnapd).toHaveBeenCalled()
+  expect(ensureLXD).not.toHaveBeenCalled()
+  expect(ensureSnapcraft).toHaveBeenCalled()
+  expect(execMock).not.toHaveBeenCalled()
+})
+
 test('SnapcraftBuilder.outputSnap fails if there are no snaps', async () => {
   expect.assertions(2)
 
@@ -61,7 +158,7 @@ test('SnapcraftBuilder.outputSnap fails if there are no snaps', async () => {
   expect(readdir).toHaveBeenCalled()
 })
 
-test('SnapcraftBuilder.outputSnap returns the first snap', async () => {
+test('SnapcraftBuilder.outputSnap returns all the snaps', async () => {
   expect.assertions(2)
 
   const projectDir = 'project-root'
@@ -73,6 +170,9 @@ test('SnapcraftBuilder.outputSnap returns the first snap', async () => {
       async (path: string): Promise<string[]> => ['one.snap', 'two.snap']
     )
 
-  await expect(builder.outputSnap()).resolves.toEqual('project-root/one.snap')
+  await expect(builder.outputSnap()).resolves.toEqual([
+    'project-root/one.snap',
+    'project-root/two.snap'
+  ])
   expect(readdir).toHaveBeenCalled()
 })

--- a/dist/index.js
+++ b/dist/index.js
@@ -1314,14 +1314,14 @@ const tools = __importStar(__webpack_require__(735));
 const fs = __webpack_require__(747); // eslint-disable-line @typescript-eslint/no-require-imports
 class SnapcraftBuilder {
     constructor(projectRoot) {
-        var _a, _b, _c;
+        var _a, _b;
         this.projectRoot = projectRoot;
         const useLaunchpad = (_a = core.getInput('use_launchpad'), (_a !== null && _a !== void 0 ? _a : 'false'));
         this.launchpadBuild = useLaunchpad === 'true';
         const lpAcceptPublic = (_b = core.getInput('launchpad_accept_public_upload'), (_b !== null && _b !== void 0 ? _b : 'false'));
         this.launchpadAcceptPublicUpload = lpAcceptPublic === 'true';
-        const lpTimeout = (_c = core.getInput('launchpad_timeout'), (_c !== null && _c !== void 0 ? _c : '3600'));
-        this.launchpadTimeout = parseInt(lpTimeout);
+        const lpTimeout = parseInt(core.getInput('launchpad_timeout'));
+        this.launchpadTimeout = Number.isNaN(lpTimeout) ? 3600 : lpTimeout;
     }
     build() {
         return __awaiter(this, void 0, void 0, function* () {

--- a/src/build.ts
+++ b/src/build.ts
@@ -10,24 +10,58 @@ import fs = require('fs') // eslint-disable-line @typescript-eslint/no-require-i
 
 export class SnapcraftBuilder {
   projectRoot: string
+  launchpadBuild: boolean
+  launchpadAcceptPublicUpload: boolean
+  launchpadTimeout: number
 
   constructor(projectRoot: string) {
     this.projectRoot = projectRoot
+
+    const useLaunchpad = core.getInput('use_launchpad') ?? 'false'
+    this.launchpadBuild = useLaunchpad === 'true'
+
+    const lpAcceptPublic =
+      core.getInput('launchpad_accept_public_upload') ?? 'false'
+    this.launchpadAcceptPublicUpload = lpAcceptPublic === 'true'
+
+    const lpTimeout = core.getInput('launchpad_timeout') ?? '3600'
+    this.launchpadTimeout = parseInt(lpTimeout)
   }
 
   async build(): Promise<void> {
     core.startGroup('Installing Snapcraft plus dependencies')
     await tools.ensureSnapd()
-    await tools.ensureLXD()
     await tools.ensureSnapcraft()
+    if (!this.launchpadBuild) {
+      await tools.ensureLXD()
+    }
     core.endGroup()
-    await exec.exec(
-      'sudo',
-      ['env', 'SNAPCRAFT_BUILD_ENVIRONMENT=lxd', 'snapcraft'],
-      {
-        cwd: this.projectRoot
+
+    const execOpts = {
+      cwd: this.projectRoot
+    }
+    if (this.launchpadBuild) {
+      if (!this.launchpadAcceptPublicUpload) {
+        throw new Error(
+          'Launchpad builds are publically accessible. You must acknowledge this by setting "launchpad_accept_public_upload" to true.'
+        )
       }
-    )
+      await exec.exec(
+        'snapcraft',
+        [
+          'remote-build',
+          '--launchpad-accept-public-upload',
+          `--launchpad-timeout=${this.launchpadTimeout}`
+        ],
+        execOpts
+      )
+    } else {
+      await exec.exec(
+        'sudo',
+        ['env', 'SNAPCRAFT_BUILD_ENVIRONMENT=lxd', 'snapcraft'],
+        execOpts
+      )
+    }
   }
 
   // This wrapper is for the benefit of the tests, due to the crazy
@@ -36,16 +70,13 @@ export class SnapcraftBuilder {
     return await fs.promises.readdir(dir)
   }
 
-  async outputSnap(): Promise<string> {
+  async outputSnap(): Promise<string[]> {
     const files = await this._readdir(this.projectRoot)
     const snaps = files.filter(name => name.endsWith('.snap'))
 
     if (snaps.length === 0) {
       throw new Error('No snap files produced by build')
     }
-    if (snaps.length > 1) {
-      core.warning(`Multiple snaps found in ${this.projectRoot}`)
-    }
-    return path.join(this.projectRoot, snaps[0])
+    return snaps.map(snap => path.join(this.projectRoot, snap))
   }
 }

--- a/src/build.ts
+++ b/src/build.ts
@@ -24,8 +24,8 @@ export class SnapcraftBuilder {
       core.getInput('launchpad_accept_public_upload') ?? 'false'
     this.launchpadAcceptPublicUpload = lpAcceptPublic === 'true'
 
-    const lpTimeout = core.getInput('launchpad_timeout') ?? '3600'
-    this.launchpadTimeout = parseInt(lpTimeout)
+    const lpTimeout = parseInt(core.getInput('launchpad_timeout'))
+    this.launchpadTimeout = Number.isNaN(lpTimeout) ? 3600 : lpTimeout
   }
 
   async build(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,8 +10,8 @@ async function run(): Promise<void> {
 
     const builder = new SnapcraftBuilder(path)
     await builder.build()
-    const snap = await builder.outputSnap()
-    core.setOutput('snap', snap)
+    const snaps = await builder.outputSnap()
+    core.setOutput('snap', snaps.join(':'))
   } catch (error) {
     core.setFailed(error.message)
   }


### PR DESCRIPTION
(potentially) BREAKING change:
  - If multiple snap packages are found in the project directory then all snap packages found will be returned separated by colons: `:`

I will report back once I've had a chance to test this on a real snap package.

Fixes #3 for projects that don't mind their source being public via Launchpad.

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>